### PR TITLE
[FIX] point_of_sale: syncedOrders.toShow

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -834,7 +834,10 @@ export class TicketScreen extends Component {
 
         const ids = ordersInfo.map((info) => info[0]);
         this._state.syncedOrders.totalCount = totalCount;
-        this._state.syncedOrders.toShow = ids.map((id) => this._state.syncedOrders.cache[id]);
+
+        // Eliminar ordenes undefined
+        // this._state.syncedOrders.toShow = ids.map((id) => this._state.syncedOrders.cache[id]);
+        this._state.syncedOrders.toShow = ids.map((id) => this._state.syncedOrders.cache[id]).filter(order => order !== undefined);
     }
     _getLastPage() {
         const totalCount = this._state.syncedOrders.totalCount;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When pressing the Refund button in the Point of Sale (POS), an error occurs due to incomplete orders returned by getFilteredOrderList().
This happens because the method filters orders to which the cashier does not have access, causing some orders to lack the cid property.

Current behavior before PR:
getFilteredOrderList() includes filtered orders that may be incomplete.
When processing a refund, the POS crashes with: TypeError: Cannot read properties of undefined (reading 'cid')
The crash happens because cid is being accessed in orders that do not have this property.

Desired behavior after PR is merged:
getFilteredOrderList() only returns valid and complete orders.
✔ The POS no longer crashes when pressing Refund.
✔ The refund process works correctly, even when the cashier does not have access to all orders.
✔ Improved stability and security in order filtering.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
